### PR TITLE
feat: [WLEO-498] Improve Android verifier certificates validation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,7 +77,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "it.pagopa.io.wallet.proximity:proximity:2.0.0"
+  implementation "it.pagopa.io.wallet.proximity:proximity:2.1.0"
   implementation "it.pagopa.io.wallet.cbor:cbor:1.3.0"
 }
 


### PR DESCRIPTION
### Short description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR improves the verifier certificates validation algorithm. More information can be found in [this PR.](https://github.com/pagopa/iso18013-android/pull/28)
#### List of Changes

<!--- Describe your changes in detail -->
- Update the native Android SDK;
- Update the Android parsing function to accept a 2D-array;

#### How Has This Been Tested?
This can be tested by passing a 2D-array of certificates to the start method. After scanning the QR code check the console and it should print the request object, including the isAuthenticated boolean flag.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->