### PR TITLE
refactor: [WLEO-556] Expose listeners

### DIFF
--- a/src/iso18013/iso18013-5/README.md
+++ b/src/iso18013/iso18013-5/README.md
@@ -18,14 +18,16 @@ This library emits the following events:
 | onDeviceDisconnected | `undefined` | Event dispatched when the verifier app disconnects. |
 | onError | `{ error: string } \| undefined` | Event dispatched when an error occurs which is contained in the error payload. It can be parsed via the `parseError` provided [here](src/schema.ts). |
 
-Listeners can be added using the `addListener` method and removed using the `removeListener` method.
+Listeners can be added using the `addListener` method and removed by using the returned reference by calling the `remove` method.
 
 ```typescript
 import { ISO18013_5 } from '@pagopa/io-react-native-iso18013';
 
-ISO18013_5.addListener('event', () => console.log('event occurred'));
+const listener = ISO18013_5.addListener('event', () =>
+  console.log('event occurred')
+);
 
-ISO18013_5.removeListener('event');
+listener.remove();
 ```
 
 #### `onDeviceConnecting`
@@ -173,7 +175,7 @@ await ISO18013_5.sendErrorResponse({
 
 Closes the QR engagement by releasing the resources allocated during the `start` method.
 Before starting a new flow, it is necessary to call this method to ensure that the previous flow is properly closed.
-The listeners can be removed using the `removeListener` method.
+Listeners can be added using the `addListener` method and removed using the `removeListener` method.
 
 ```typescript
 import { ISO18013_5 } from '@pagopa/io-react-native-iso18013';

--- a/src/iso18013/iso18013-5/index.ts
+++ b/src/iso18013/iso18013-5/index.ts
@@ -20,7 +20,6 @@ export {
   close,
   generateResponse,
   getQrCodeString,
-  removeListener,
   sendErrorResponse,
   sendResponse,
   start,

--- a/src/iso18013/iso18013-5/proximity.ts
+++ b/src/iso18013/iso18013-5/proximity.ts
@@ -122,13 +122,5 @@ export function addListener<E extends Events>(
   event: E,
   callback: (data: EventsPayload[E]) => void
 ) {
-  eventEmitter.addListener(event, callback);
-}
-
-/**
- * Removes a listener for a `QrEngagementEvents` event.
- * @param event - The event to remove the listener for. The available events are defined in the `QrEngagementEvents` type.
- */
-export function removeListener(event: Events) {
-  eventEmitter.removeAllListeners(event);
+  return eventEmitter.addListener(event, callback);
 }


### PR DESCRIPTION
### Short description
This PR exposes the listener created by `addListener` in order to call the `remove` method. It also removes the `removeListener` function as it doesn't work as intended, thus the reference to the listener can be used by calling the`remove` method instead.
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Return the listener reference in `addListener`; 
- Remove the `removeListener` method;
- Update the documentation.
<!--- Describe your changes in detail -->

#### How Has This Been Tested?
This can be tested with the example app by starting and closing a proximity flow.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->