### PR TITLE
feat: [SIW-4084] Add verifier's certificate data to proximity verification request

### DIFF
--- a/IoReactNativeIso18013.podspec
+++ b/IoReactNativeIso18013.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   # Module dependencies
   s.dependency "IOWalletCBOR", "0.2.1"
-  s.dependency "IOWalletProximity", "1.4.2"
+  s.dependency "IOWalletProximity", "1.5.0"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,8 +83,8 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "it.pagopa.io.wallet.proximity:proximity:2.4.1"
-  implementation "it.pagopa.io.wallet.cbor:cbor:1.4.1"
+  implementation "it.pagopa.io.wallet.proximity:proximity:2.5.0"
+  implementation "it.pagopa.io.wallet.cbor:cbor:1.4.2"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
   testImplementation('junit:junit:4.13.2')
 }

--- a/android/src/main/java/com/ioreactnativeiso18013/IoReactNativeIso18013Module.kt
+++ b/android/src/main/java/com/ioreactnativeiso18013/IoReactNativeIso18013Module.kt
@@ -106,8 +106,7 @@ class IoReactNativeIso18013Module(reactContext: ReactApplicationContext) :
       // NFC engagement
 
       if (parsedEngagementModes.any { it == EngagementMode.NFC }) {
-        val readerTrustStore = certificatesList.takeIf { it.isNotEmpty() }
-          ?.map { chain -> chain.map<ByteArray, Any> { it } }
+        val readerTrustStore = certificatesList.map { chain -> chain.map<ByteArray, Any> { it } }
 
         check(
           NfcEngagementEventBus.setupNfcService(
@@ -127,9 +126,7 @@ class IoReactNativeIso18013Module(reactContext: ReactApplicationContext) :
 
       if (parsedEngagementModes.any { it == EngagementMode.QR_CODE }) {
         qrEngagement = QrEngagement.build(reactApplicationContext, methods).apply {
-          if (certificatesList.isNotEmpty()) {
-            withReaderTrustStore(certificatesList)
-          }
+          withReaderTrustStore(certificatesList)
         }
         qrEngagement?.configure()
         setupProximityHandler()

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
     - glog
     - hermes-engine
     - IOWalletCBOR (= 0.2.1)
-    - IOWalletProximity (= 1.4.2)
+    - IOWalletProximity (= 1.5.0)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -39,7 +39,7 @@ PODS:
     - SocketRocket
     - Yoga
   - IOWalletCBOR (0.2.1)
-  - IOWalletProximity (1.4.2)
+  - IOWalletProximity (1.5.0)
   - OpenSSL-Universal (3.6.0000)
   - pagopa-io-react-native-crypto (1.2.4):
     - boost
@@ -2802,9 +2802,9 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  IoReactNativeIso18013: 0095a9b361a2229760992bd71861723a74248b2f
+  IoReactNativeIso18013: acf08aa5539091f411636368e633e136abc4835a
   IOWalletCBOR: 92742ef1cbd1b627ba153d0c7c11b81ad22f45cc
-  IOWalletProximity: 686e68830d7e624027829866325581f0ed2d8131
+  IOWalletProximity: c55c362307fcfd757044d930e49bc3a1cc562aa2
   OpenSSL-Universal: 9110d21982bb7e8b22a962b6db56a8aa805afde7
   pagopa-io-react-native-crypto: 8bd5ec4b5b6af1a03416f3c8267530eac9f6f724
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669

--- a/example/src/iso18013/Iso180135Screen.tsx
+++ b/example/src/iso18013/Iso180135Screen.tsx
@@ -1,5 +1,5 @@
 import { ISO18013_5 } from '@pagopa/io-react-native-iso18013';
-import { Button, ScrollView, Text } from 'react-native';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 import { styles } from '../styles';
 import { PROXIMITY_STATUS, useProximityFlow } from './hooks/useProximityFlow';
@@ -60,6 +60,11 @@ const Iso180135Screen: React.FC = () => {
       )}
       {status === PROXIMITY_STATUS.PRESENTING && request && (
         <>
+          <View style={localStyles.requestInfoWrapper}>
+            {Object.entries(request).map(([doc, req], index) => (
+              <RequestInfo key={index} doc={doc} request={req} />
+            ))}
+          </View>
           <Button
             title="Send document (base64)"
             onPress={() => sendDocument(request, MDL_BASE64)}
@@ -98,5 +103,37 @@ const Iso180135Screen: React.FC = () => {
     </ScrollView>
   );
 };
+
+const RequestInfo = ({
+  doc,
+  request,
+}: {
+  doc: string;
+  request: ISO18013_5.VerifierRequest['request'][0];
+}) => {
+  return (
+    <View style={localStyles.requestInfoContainer}>
+      <Text style={localStyles.requestInfoTitle}>Request for {doc}</Text>
+      <Text>{JSON.stringify(request, null, 2)}</Text>
+    </View>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  requestInfoWrapper: {
+    gap: 16,
+    width: '100%',
+  },
+  requestInfoContainer: {
+    width: '100%',
+    marginVertical: 10,
+    backgroundColor: 'white',
+    padding: 16,
+    gap: 16,
+  },
+  requestInfoTitle: {
+    fontWeight: 'bold',
+  },
+});
 
 export default Iso180135Screen;

--- a/example/src/iso18013/Iso180135Screen.tsx
+++ b/example/src/iso18013/Iso180135Screen.tsx
@@ -60,11 +60,7 @@ const Iso180135Screen: React.FC = () => {
       )}
       {status === PROXIMITY_STATUS.PRESENTING && request && (
         <>
-          <View style={localStyles.requestInfoWrapper}>
-            {Object.entries(request).map(([doc, req], index) => (
-              <RequestInfo key={index} doc={doc} request={req} />
-            ))}
-          </View>
+          <RequestInfo request={request} />
           <Button
             title="Send document (base64)"
             onPress={() => sendDocument(request, MDL_BASE64)}
@@ -105,16 +101,18 @@ const Iso180135Screen: React.FC = () => {
 };
 
 const RequestInfo = ({
-  doc,
   request,
 }: {
-  doc: string;
-  request: ISO18013_5.VerifierRequest['request'][0];
+  request: ISO18013_5.VerifierRequest['request'];
 }) => {
   return (
-    <View style={localStyles.requestInfoContainer}>
-      <Text style={localStyles.requestInfoTitle}>Request for {doc}</Text>
-      <Text>{JSON.stringify(request, null, 2)}</Text>
+    <View style={localStyles.requestInfoWrapper}>
+      {Object.entries(request).map(([doc, req], index) => (
+        <View key={`request_${index}`} style={localStyles.requestInfoContainer}>
+          <Text style={localStyles.requestInfoTitle}>Request for {doc}</Text>
+          <Text>{JSON.stringify(req, null, 2)}</Text>
+        </View>
+      ))}
     </View>
   );
 };

--- a/ios/IoReactNativeIso18013.swift
+++ b/ios/IoReactNativeIso18013.swift
@@ -398,10 +398,10 @@ class IoReactNativeIso18013: RCTEventEmitter, ISO18013Delegate {
   /**
    Converts a device requested from the `onDocumentRequestReceived` callback into a serializable JSON.
    - Parameters:
-   - request: The request returned from `onDocumentRequestReceived` which contains an array of tuples consists of a doctype, namespaces and the requested claims with a boolean value indicating wether or not the device which is making the request has an intent to retain the data.
+   - request: The request returned from `onDocumentRequestReceived` which contains an array of tuples consists of a doctype, namespaces, the requested claims with a boolean value indicating wether or not the device which is making the request has an intent to retain the data, and optional certificate data from the verifier X.509 certificate.
    - Returns: A JSON string representing the device request or nil if an error occurs.
    */
-  private func deviceRequestToJson(request: [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool)]?) -> String? {
+  private func deviceRequestToJson(request: [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool, certificateData: [String: String]?)]?) -> String? {
     var jsonRequest : [String: AnyHashable] = [:]
     request?.forEach({
       item in
@@ -412,6 +412,9 @@ class IoReactNativeIso18013: RCTEventEmitter, ISO18013Delegate {
       })
       
       subReq["isAuthenticated"] = item.isAuthenticated
+      if let certData = item.certificateData {
+        subReq["certificateData"] = certData
+      }
       
       jsonRequest[item.docType] = subReq
     })

--- a/src/iso18013/iso18013-5/request.ts
+++ b/src/iso18013/iso18013-5/request.ts
@@ -3,9 +3,26 @@ import { z } from 'zod';
 // Inner data: a record of booleans with the attributes and the intent to retain flag
 const booleanFieldGroup = z.record(z.string(), z.boolean());
 
+// Parses raw X.509 subject fields from the verifier certificate
+// and maps them to readable internal names.
+const certificateDataSchema = z
+  .object({
+    C: z.string().optional(),
+    O: z.string().optional(),
+    SERIALNUMBER: z.string().optional(),
+    CN: z.string().optional(),
+  })
+  .transform((certificate) => ({
+    country: certificate.C,
+    organization: certificate.O,
+    serialNumber: certificate.SERIALNUMBER,
+    commonName: certificate.CN,
+  }));
+
 const credentialEntrySchema = z
   .object({
     isAuthenticated: z.boolean(),
+    certificateData: certificateDataSchema.optional(),
   })
   .catchall(booleanFieldGroup);
 
@@ -20,12 +37,18 @@ const VerifierRequest = z.object({
  * Example:
  *  `{
  *    "org.iso.18013.5.1.mDL": {
- *      "isAuthenticated": true,
  *      "org.iso.18013.5.1": {
  *        "hair_colour": true,
  *        "given_name_national_character": true,
  *        "family_name_national_character": true,
  *        "given_name": true,
+ *      },
+ *      "isAuthenticated": true,
+ *      "certificateData": {
+ *        "country": "UT",
+ *        "organization": "EUDI Wallet Reference Implementation",
+ *        "serialNumber": "001",
+ *        "commonName": "EUDI Proximity Verifier"
  *      }
  *    }
  *  }`


### PR DESCRIPTION
### Short description

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR adds verifier's certificate information in the proximity presentation request

#### List of Changes

<!--- Describe your changes in detail -->

- (iOS) Bumped `IOWalletProximity` to 1.5.0 
- (Android) Bumped `it.pagopa.io.wallet.proximity:proximity` to 2.5.0
- (Android) Bumped `it.pagopa.io.wallet.cbor:cbor` to 1.4.2
- Updated `VerifierRequest` Zod schema with `certificateData` payload
- Updated example app to display certificate data (if available) 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Try a proximity presentation and verify certificated data is correctly received, if available.
Not all verifier apps send certificate information.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->
<img width="350"  alt="5B823BAD-232C-4BE8-9961-942942335D76_1_102_o" src="https://github.com/user-attachments/assets/4f26f0ba-49aa-4edf-bd1f-4a2b1630fb3a" />

